### PR TITLE
Update build.gradle to use SDK build tools 31.0.0.

### DIFF
--- a/RenderScriptMigrationSample/README.md
+++ b/RenderScriptMigrationSample/README.md
@@ -12,7 +12,8 @@ Both tasks are implemented with RenderScript (intrinsics & custom scripts) and V
 
 ## Pre-requisites
 
-- Android Studio 4.0+
+- Android Studio Arctic Fox 2020.3.1+
+- SDK Build Tools 31.0.0+
 - NDK r20+
 - Android API 29+
 

--- a/RenderScriptMigrationSample/app/build.gradle
+++ b/RenderScriptMigrationSample/app/build.gradle
@@ -2,13 +2,20 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion 31
+
+    // When building this project with with SDK build tools of version earlier than 31.0.0, and
+    // minSdkVersion 29+, the RenderScript compiler will fail with the following error message:
+    //
+    //     error: target API level '29' is out of range ('11' - '24')
+    //
+    // This issue has been fixed in SDK build tools 31.0.0.
+    buildToolsVersion '31.0.0'
 
     defaultConfig {
         applicationId "com.android.example.rsmigration"
         minSdkVersion 29
-        targetSdkVersion 30
+        targetSdkVersion 31
         ndkVersion '22.0.7026061'
         renderscriptTargetApi 24
         versionCode 1
@@ -50,10 +57,10 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/RenderScriptMigrationSample/app/src/main/AndroidManifest.xml
+++ b/RenderScriptMigrationSample/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/RenderScriptMigrationSample/build.gradle
+++ b/RenderScriptMigrationSample/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/RenderScriptMigrationSample/gradle/wrapper/gradle-wrapper.properties
+++ b/RenderScriptMigrationSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
The RenderScript compiler in the SDK build tools of a version earlier
than 31.0.0 will fail to build a RenderScript app with minSdkVersion
29+.